### PR TITLE
chore: update gem and CI dependencies (Rails 7.1, Ruby 3.3)

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v4
+    - name: Set up Ruby 3.3
+      uses: ruby/setup-ruby@v1
       with:
-        version: 2.6.x
+        ruby-version: 3.3
 
     - name: Publish to GPR
       run: |

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v4
+    - name: Set up Ruby 3.3
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 3.3
     - name: Build and test with Rake
       run: |
         gem install bundler

--- a/background_removal.gemspec
+++ b/background_removal.gemspec
@@ -23,10 +23,13 @@ Gem::Specification.new do |s|
   # s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.require_paths     = ['lib']
 
-  s.add_dependency 'rails', '~> 5.1.1'
-  s.add_dependency 'sqlite3'
-  s.add_development_dependency 'mechanize'
-  s.add_development_dependency 'pg'
-  s.add_development_dependency 'rmagick'
-  s.add_development_dependency 'rspec-rails'
+  s.required_ruby_version = '>= 3.1'
+
+  s.add_dependency 'rails', '~> 7.1'
+  s.add_dependency 'sqlite3', '~> 1.7'
+
+  s.add_development_dependency 'mechanize', '~> 2.14'
+  s.add_development_dependency 'pg', '~> 1.6'
+  s.add_development_dependency 'rmagick', '~> 6.1'
+  s.add_development_dependency 'rspec-rails', '~> 8.0'
 end


### PR DESCRIPTION
### Motivation
- Bring the gem up-to-date with modern Ruby and Rails by moving runtime and dev dependencies to current major releases.  
- Require a newer Ruby runtime to match updated dependency compatibility.  
- Modernize CI to use current GitHub Actions and a supported Ruby version for builds and publishing.  

### Description
- Set `s.required_ruby_version = '>= 3.1'` and bumped runtime dependencies to `rails ~> 7.1` and `sqlite3 ~> 1.7` in `background_removal.gemspec`.  
- Updated development dependencies in the gemspec to `mechanize ~> 2.14`, `pg ~> 1.6`, `rmagick ~> 6.1`, and `rspec-rails ~> 8.0`.  
- Replaced `actions/checkout@v2` with `actions/checkout@v4` and switched from the deprecated `actions/setup-ruby@v1` to `ruby/setup-ruby@v1` in workflows.  
- Raised the CI Ruby version from `2.6` to `3.3` in `.github/workflows/gempush.yml` and `.github/workflows/ruby.yml`.  

### Testing
- Validated the modified gemspec syntax with `ruby -c background_removal.gemspec`, which succeeded.  
- Performed a workflow file validation step and found no syntax issues after edits.  
- Attempted to run `bundle update` to refresh the lockfile, but it failed due to a `403 Forbidden` when fetching the Rubygems index, so `Gemfile.lock` was not regenerated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f72d916b208332a5b59f9f22b1e538)